### PR TITLE
More flexible paramter combination on `connect`.

### DIFF
--- a/python/core.cc
+++ b/python/core.cc
@@ -184,7 +184,6 @@ void bind_core(py::module& mod) {
       .def(py::init<>())
       .def(py::init<ObjectID>(), "id"_a)
       .def(py::init<std::string const&>(), "id"_a)
-      .def(py::init<const char*>(), "id"_a)
       .def("__int__", [](const ObjectIDWrapper& id) { return ObjectID(id); })
       .def("__repr__",
            [](const ObjectIDWrapper& id) { return VYObjectIDToString(id); })

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -42,6 +42,38 @@ add_doc(
 
     Returns:
         RPCClient: The connected RPC client.
+
+.. function:: connect(endpoint: (str, int or str)) -> RPCClient
+    :noindex:
+
+    Connect to vineyard via TCP socket.
+
+    Parameters:
+        endpoint: tuple(str, int or str)
+            Endpoint to connect to. The parameter is a tuple, in which the first element
+            is the host, and the second parameter, can be int a str, is the port.
+
+    Returns:
+        RPCClient: The connected RPC client.
+
+.. function:: connect() -> IPCClient or RPCClient
+    :noindex:
+
+    Connect to vineyard via UNIX domain socket or TCP endpoint. This method normally
+    usually no arguments, and will first tries to resolve IPC socket from the
+    environment variable `VINEYARD_IPC_SOCKET` and connect to it. If it fails to
+    establish a connection with vineyard server, the method will tries to resolve
+    RPC endpoint from the environment variable `VINEYARD_RPC_ENDPOINT`.
+
+    If both tries are failed, this method will raise a :class:`ConnectionFailed`
+    exception.
+
+    In rare cases, user may be not sure about if the IPC socket or RPC endpoint
+    is avaiable, i.e., the varaible might be :code:`None`. In such cases this method
+    can accept a `None` as arguments, and do resolution as described above.
+
+    Raises:
+        ConnectionFailed
 ''')
 
 add_doc(

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -126,7 +126,7 @@ class Client : public ClientBase {
   ~Client() override;
 
   /**
-   * @brief Connect to vineyard using the UNIX domain socket file pointed by
+   * @brief Connect to vineyard using the UNIX domain socket file specified by
    *        the environment variable `VINEYARD_IPC_SOCKET`.
    *
    * @return Status that indicates whether the connect has succeeded.
@@ -145,7 +145,7 @@ class Client : public ClientBase {
 
   /**
    * @brief Get a default client reference, using the UNIX domain socket file
-   *        pointed by the environment variable `VINEYARD_IPC_SOCKET`.
+   *        specified by the environment variable `VINEYARD_IPC_SOCKET`.
    *
    * @return A reference of the default Client instance.
    */

--- a/src/client/rpc_client.cc
+++ b/src/client/rpc_client.cc
@@ -29,6 +29,14 @@ limitations under the License.
 
 namespace vineyard {
 
+Status RPCClient::Connect() {
+  if (const char* env_p = std::getenv("VINEYARD_RPC_ENDPOINT")) {
+    return Connect(std::string(env_p));
+  }
+  return Status::ConnectionError(
+      "Environment variable VINEYARD_RPC_ENDPOINT does't exists");
+}
+
 Status RPCClient::Connect(const std::string& rpc_endpoint) {
   size_t pos = rpc_endpoint.find(":");
   std::string host, port;

--- a/src/client/rpc_client.h
+++ b/src/client/rpc_client.h
@@ -35,6 +35,14 @@ class RPCClient : public ClientBase {
   ~RPCClient() override;
 
   /**
+   * @brief Connect to vineyard using the TCP endpoint specified by
+   *        the environment variable `VINEYARD_RPC_ENDPOINT`.
+   *
+   * @return Status that indicates whether the connect has succeeded.
+   */
+  Status Connect();
+
+  /**
    * @brief Connect to vineyardd using the given TCP endpoint `rpc_endpoint`.
    *
    * @param rpc_endpoint The TPC endpoint of vineyard server, in the format of

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -335,9 +335,9 @@ class VINEYARD_MUST_USE_TYPE Status {
   }
 
   /// Return an error when client failed to connect to vineyard server.
-  static Status ConnectionFailed() {
+  static Status ConnectionFailed(std::string const& message = "") {
     return Status(StatusCode::kConnectionFailed,
-                  "Failed to connect to vineyardd.");
+                  "Failed to connect to vineyardd: " + message);
   }
 
   /// Return an error when client losts connection to vineyard server.


### PR DESCRIPTION
Now the `connect` in Python and `Connect` in C++ can resolve vineyard socket, both for IPC client and RPC client, from the environment variable `VINEYARD_IPC_SOCKET` and `VINEYARD_RPC_ENDPOINT`.