### PR TITLE
Fixes a bug in DeleteBlobBatch, also revise `delVal`.

### DIFF
--- a/modules/basic/ds/pair.h
+++ b/modules/basic/ds/pair.h
@@ -69,6 +69,18 @@ class PairBuilder : public PairBaseBuilder {
   }
 
   /**
+   * @brief Set the builder for the first element.
+   * When building the pair, the builder will be invoked to build
+   * the first element.
+   *
+   * @param first The value for the first object.
+   */
+  void SetFirst(std::shared_ptr<Object> const& first) {
+    VINEYARD_ASSERT(this->first_ == nullptr);
+    this->set_first_(first);
+  }
+
+  /**
    * @brief Set the builder for the second element.
    * When building the pair, the builder will be invoked to build
    * the second element.
@@ -76,6 +88,18 @@ class PairBuilder : public PairBaseBuilder {
    * @param second The builder for the second object.
    */
   void SetSecond(std::shared_ptr<ObjectBuilder> const& second) {
+    VINEYARD_ASSERT(this->second_ == nullptr);
+    this->set_second_(second);
+  }
+
+  /**
+   * @brief Set the builder for the second element.
+   * When building the pair, the builder will be invoked to build
+   * the second element.
+   *
+   * @param second The value for the second object.
+   */
+  void SetSecond(std::shared_ptr<Object> const& second) {
     VINEYARD_ASSERT(this->second_ == nullptr);
     this->set_second_(second);
   }

--- a/modules/basic/ds/tuple.h
+++ b/modules/basic/ds/tuple.h
@@ -92,9 +92,25 @@ class TupleBuilder : public TupleBaseBuilder {
    * build the value.
    *
    * @param idx The index of the value.
-   * @param value The builder for the value at the given index.
+   * @param value The builder for the value for the given index.
    */
   void SetValue(size_t idx, std::shared_ptr<ObjectBuilder> const& value) {
+    if (idx >= size_) {
+      LOG(ERROR) << "tuple::set(): out of range";
+    } else {
+      this->set_elements_(idx, value);
+    }
+  }
+
+  /**
+   * @brief Set the builder for the value at the given index.
+   * When building the tuple, the builder will be invoked to
+   * build the value.
+   *
+   * @param idx The index of the value.
+   * @param value The value for the given index.
+   */
+  void SetValue(size_t idx, std::shared_ptr<Object> const& value) {
     if (idx >= size_) {
       LOG(ERROR) << "tuple::set(): out of range";
     } else {

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -389,7 +389,7 @@ Status VineyardServer::DelData(const std::vector<ObjectID>& ids,
 
 Status VineyardServer::DeleteBlobBatch(const std::set<ObjectID>& ids) {
   for (auto object_id : ids) {
-    RETURN_ON_ERROR(this->bulk_store_->ProcessDeleteRequest(object_id));
+    VINEYARD_SUPPRESS(this->bulk_store_->ProcessDeleteRequest(object_id));
   }
   return Status::OK();
 }

--- a/src/server/services/meta_service.cc
+++ b/src/server/services/meta_service.cc
@@ -67,7 +67,8 @@ void IMetaService::incRef(std::string const& key, std::string const& value) {
 }
 
 bool IMetaService::deleteable(ObjectID const object_id) {
-  return supobjects_.find(object_id) == supobjects_.end();
+  return object_id != InvalidObjectID() &&
+         supobjects_.find(object_id) == supobjects_.end();
 }
 
 void IMetaService::traverseToDelete(std::set<ObjectID>& initial_delete_set,

--- a/test/rpc_delete_test.cc
+++ b/test/rpc_delete_test.cc
@@ -28,6 +28,8 @@ limitations under the License.
 #include "glog/logging.h"
 
 #include "basic/ds/array.h"
+#include "basic/ds/pair.h"
+#include "basic/ds/tuple.h"
 #include "client/client.h"
 #include "client/ds/object_meta.h"
 #include "client/rpc_client.h"
@@ -226,6 +228,55 @@ int main(int argc, char** argv) {
     auto s = client.GetBuffers({blob_id}, objects);
     CHECK(s.ok() && objects.size() == 0);
   }
+
+  // delete on complex data: and empty blob is quite special, since it cannot
+  // been truely deleted.
+  std::shared_ptr<InstanceStatus> status_before;
+  VINEYARD_CHECK_OK(rpc_client.InstanceStatus(status_before));
+
+  // prepare data
+  ObjectID nested_tuple_id;
+  {
+    // prepare data
+    std::vector<double> double_array1 = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder1(client, double_array1);
+
+    std::vector<double> double_array2 = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder2(client, double_array2);
+
+    std::vector<double> double_array3 = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder3(client, double_array3);
+
+    std::vector<double> double_array4 = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder4(client, double_array4);
+
+    PairBuilder pair_builder1(client);
+    pair_builder1.SetFirst(builder1.Seal(client));
+    pair_builder1.SetSecond(builder2.Seal(client));
+
+    PairBuilder pair_builder2(client);
+    pair_builder2.SetFirst(builder3.Seal(client));
+    pair_builder2.SetSecond(Blob::MakeEmpty(client));
+
+    PairBuilder pair_builder3(client);
+    pair_builder3.SetFirst(Blob::MakeEmpty(client));
+    pair_builder3.SetSecond(builder4.Seal(client));
+
+    TupleBuilder tuple_builder(client);
+    tuple_builder.SetSize(3);
+    tuple_builder.SetValue(0, pair_builder1.Seal(client));
+    tuple_builder.SetValue(1, pair_builder2.Seal(client));
+    tuple_builder.SetValue(2, pair_builder3.Seal(client));
+    nested_tuple_id = tuple_builder.Seal(client)->id();
+  }
+  VINEYARD_CHECK_OK(rpc_client.DelData(nested_tuple_id, true, true));
+
+  std::shared_ptr<InstanceStatus> status_after;
+  VINEYARD_CHECK_OK(rpc_client.InstanceStatus(status_after));
+
+  // validate memory usage
+  CHECK_EQ(status_before->memory_limit, status_after->memory_limit);
+  CHECK_EQ(status_before->memory_usage, status_after->memory_usage);
 
   LOG(INFO) << "Passed delete with rpc tests...";
 


### PR DESCRIPTION
When fail to delete some blobs, continue to delete others.

The blobs that cannot be delete are empty blobs: the empty blob doesn't do real memory allocation and has address `0x0`, that, cannot be processed by `dlmalloc`, thus the failure, causing subquential blobs are failed to be deleted as well.