### PR TITLE
Fixes a bug in get remote object (when its members includes blobs).

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -320,7 +320,7 @@ void bind_client(py::module& mod) {
                                                                 "RPCClient")
       .def(
           "get_object",
-          [](Client* self, const ObjectIDWrapper object_id) {
+          [](RPCClient* self, const ObjectIDWrapper object_id) {
             return self->GetObject(object_id);
           },
           "object_id"_a)


### PR DESCRIPTION
Errors:

```cpp
E1201 11:25:29.439462    55 object_meta.cc:132] Check failed: Assertion failed: child_meta: Failed to get member buffer_ in "::vineyard::Status::AssertionFailed( std::string("child_meta" ": ") + "Failed to get member " + name)"
E1201 11:25:29.441027    56 object_meta.cc:132] Check failed: Assertion failed: child_meta: Failed to get member buffer_ in "::vineyard::Status::AssertionFailed( std::string("child_meta" ": ") + "Failed to get member " + name)"
E1201 11:25:29.441253    55 dispatcher.cc:74] /root/gsa/analytical_engine/core/rpc/dispatcher.cc:58: operator() -> Unmatched std::exception detected: Check failed: Assertion failed: child_meta: Failed to get member buffer_ in "::vineyard::Status::AssertionFailed( std::string("child_meta" ": ") + "Failed to get member " + name)"
E1201 11:25:29.441134    56 object_meta.cc:132] Check failed: Assertion failed: child_meta: Failed to get member buffer_ in "::vineyard::Status::AssertionFailed( std::string("child_meta" ": ") + "Failed to get member " + name)"
E1201 11:25:29.442620    56 dispatcher.cc:74] /root/gsa/analytical_engine/core/rpc/dispatcher.cc:58: operator() -> Unmatched std::exception detected: Check failed: Assertion failed: child_meta: Failed to get member buffer_ in "::vineyard::Status::AssertionFailed( std::string("child_meta" ": ") + "Failed to get member " + name)"
E1201 11:25:29.442775    56 dispatcher.cc:74] /root/gsa/analytical_engine/core/rpc/dispatcher.cc:58: operator() -> Unmatched std::exception detected: Check failed: Assertion failed: child_meta: Failed to get member buffer_ in "::vineyard::Status::AssertionFailed( std::string("child_meta" ": ") + "Failed to get member " + name)"
E1201 11:25:29.443198 96775 graphscope_service.cc:95] Error: Multiple workers return different data. Current worker id: 1  vs the previous: {
    "object_id": "003bad9ff07fdb12"
}
```

Tracepoint:

```cpp
class Tensor : public ITensor, public BareRegistered<Tensor<T>> {
  
  public:
    static std::shared_ptr<Object> Create() __attribute__((used)) {
        return std::static_pointer_cast<Object>(std::make_shared<Tensor<T>>());
    }


  public:
    void Construct(const ObjectMeta& meta) override {
        std::string __type_name = type_name<Tensor<T>>();
        CHECK(meta.GetTypeName() == __type_name);
        this->meta_ = meta;
        this->id_ = meta.GetId();

        meta.GetKeyValue("value_type_", this->value_type_);
---> this->buffer_ = std::dynamic_pointer_cast<Blob>(meta.GetMember("buffer_"));
        meta.GetKeyValue("shape_", this->shape_);
        meta.GetKeyValue("partition_index_", this->partition_index_);

        
    }
```