### PR TITLE
Fixes compatiblity bug for pandas 1.2.0.

### DIFF
--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
 import json
 import numpy as np
 import pandas as pd
@@ -52,12 +51,8 @@ def dataframe_resolver(obj, resolver):
     index_size = 0
     for idx, name in enumerate(columns):
         np_value = resolver.run(obj.member('__values_-value-%d' % idx))
-        if LooseVersion(pd.__version__) < LooseVersion('1.2.0'):
-            kw = dict()
-        else:
-            # ndim: 1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
-            kw = {'ndim': 2}
-        blocks.append(Block(np.expand_dims(np_value, 0), slice(idx, idx + 1, 1), **kw))
+        # ndim: 1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
+        blocks.append(Block(np.expand_dims(np_value, 0), slice(idx, idx + 1, 1), ndim=2))
         index_size = len(np_value)
     return pd.DataFrame(BlockManager(blocks, [columns, np.arange(index_size)]))
 

--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+from distutils.version import LooseVersion
 import json
 import numpy as np
 import pandas as pd
@@ -51,7 +52,12 @@ def dataframe_resolver(obj, resolver):
     index_size = 0
     for idx, name in enumerate(columns):
         np_value = resolver.run(obj.member('__values_-value-%d' % idx))
-        blocks.append(Block(np.expand_dims(np_value, 0), slice(idx, idx + 1, 1)))
+        if LooseVersion(pd.__version__) < LooseVersion('1.2.0'):
+            kw = dict()
+        else:
+            # ndim: 1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
+            kw = {'ndim': 2}
+        blocks.append(Block(np.expand_dims(np_value, 0), slice(idx, idx + 1, 1), **kw))
         index_size = len(np_value)
     return pd.DataFrame(BlockManager(blocks, [columns, np.arange(index_size)]))
 

--- a/setup.cfg.in
+++ b/setup.cfg.in
@@ -4,7 +4,8 @@ version = @VINEYARD_VERSION@
 [options]
 install_requires =
     numpy
-    pandas < 1.2.0
+    pandas<1.2.0; python_version<'3.7'
+    pandas>=1.0.0; python_version>='3.7'
     pyarrow
     sortedcontainers
     setuptools

--- a/setup.cfg.in
+++ b/setup.cfg.in
@@ -4,6 +4,7 @@ version = @VINEYARD_VERSION@
 [options]
 install_requires =
     numpy
+    pandas<1.0.0; python_version<'3.6'
     pandas<1.2.0; python_version<'3.7'
     pandas>=1.0.0; python_version>='3.7'
     pyarrow


### PR DESCRIPTION
## What do these changes do?

Pandas 1.2.0 drops python 3.6 support, and pandas 1.0.0 drops python 3.5 support. And there's are a breaking change in python 1.2.0 that affects us.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #112 
