### PR TITLE
support sparse data structure of pandas serialize/deserialize

### DIFF
--- a/python/vineyard/data/tests/test_dataframe.py
+++ b/python/vineyard/data/tests/test_dataframe.py
@@ -45,3 +45,11 @@ def test_dataframe_set_index(vineyard_client):
     expected = df1.set_index('y', drop=True)
     object_id = vineyard_client.put(expected)
     pd.testing.assert_frame_equal(expected, vineyard_client.get(object_id))
+
+
+def test_dataframe_with_sparse_array(vineyard_client):
+    df = pd.DataFrame(np.random.randn(100, 4))
+    df.iloc[:98] = np.nan
+    sdf = df.astype(pd.SparseDtype("float", np.nan))
+    object_id = vineyard_client.put(sdf)
+    pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))

--- a/python/vineyard/data/tests/test_tensor.py
+++ b/python/vineyard/data/tests/test_tensor.py
@@ -32,6 +32,7 @@ def test_numpy_ndarray(vineyard_client):
     object_id = vineyard_client.put(arr)
     np.testing.assert_allclose(arr, vineyard_client.get(object_id))
 
+
 def test_sparse_array(vineyard_client):
     arr = np.random.randn(10)
     arr[2:5] = np.nan

--- a/python/vineyard/data/tests/test_tensor.py
+++ b/python/vineyard/data/tests/test_tensor.py
@@ -17,6 +17,7 @@
 #
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import vineyard
@@ -30,3 +31,11 @@ def test_numpy_ndarray(vineyard_client):
     arr = np.random.rand(4, 5, 6)
     object_id = vineyard_client.put(arr)
     np.testing.assert_allclose(arr, vineyard_client.get(object_id))
+
+def test_sparse_array(vineyard_client):
+    arr = np.random.randn(10)
+    arr[2:5] = np.nan
+    arr[7:8] = np.nan
+    sparr = pd.arrays.SparseArray(arr)
+    object_id = vineyard_client.put(sparr)
+    pd.testing.assert_extension_array_equal(sparr, vineyard_client.get(object_id))


### PR DESCRIPTION

## What do these changes do?
support sparse data structure of pandas serialize/deserialize

pyarrow not support serialize/deserialize sparse data, use pickle when the data not support in pyarrow.
