### PR TITLE
Fix "unknown attribute" warning when 3rd party application uses vineyard header files. 

### DIFF
--- a/modules/basic/ds/array.vineyard-mod
+++ b/modules/basic/ds/array.vineyard-mod
@@ -32,6 +32,11 @@ namespace vineyard {
 template <typename T>
 class ArrayBaseBuilder;
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 /**
  * @brief The array type in vineyard.
  *
@@ -69,6 +74,9 @@ class Array : public Registered<Array<T>> {
   friend class ArrayBaseBuilder<T>;
 };
 
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 }  // namespace vineyard
 
 #endif  // MODULES_BASIC_DS_ARRAY_MOD_H_

--- a/modules/basic/ds/arrow.vineyard-mod
+++ b/modules/basic/ds/arrow.vineyard-mod
@@ -33,6 +33,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 /// The arrays in vineyard is a wrapper of arrow arrays, in order to
 /// Simplify the Build and Construct process.
 
@@ -355,6 +360,10 @@ class Table : public Registered<Table> {
   friend class Client;
   friend class TableBaseBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/ds/dataframe.vineyard-mod
+++ b/modules/basic/ds/dataframe.vineyard-mod
@@ -37,6 +37,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 class DataFrameBaseBuilder;
 
 class DataFrame : public Registered<DataFrame> {
@@ -133,6 +138,10 @@ class GlobalDataFrame : public Registered<GlobalDataFrame> {
   friend class Client;
   friend class GlobalDataFrameBaseBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/ds/hashmap.vineyard-mod
+++ b/modules/basic/ds/hashmap.vineyard-mod
@@ -31,6 +31,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 struct __attribute__((annotate("no-vineyard"))) prime_hash_policy {
   prime_hash_policy() : current_prime_(1) {}
   prime_hash_policy(const prime_hash_policy& rhs)
@@ -225,6 +230,10 @@ class Hashmap : public Registered<Hashmap<K, V, H, E>>, public H, public E {
     return static_cast<const E&>(*this)(lhs, rhs);
   }
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/ds/pair.vineyard-mod
+++ b/modules/basic/ds/pair.vineyard-mod
@@ -28,6 +28,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 class PairBaseBuilder;
 
 class Pair : public Registered<Pair> {
@@ -93,6 +98,10 @@ class Pair : public Registered<Pair> {
   friend class Client;
   friend class PairBaseBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/ds/scalar.vineyard-mod
+++ b/modules/basic/ds/scalar.vineyard-mod
@@ -31,6 +31,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 // NB: the scalar value is write to meta json as a `string` directly,
 // without touching shared memory and create a blob.
 
@@ -69,6 +74,10 @@ class Scalar : public Registered<Scalar<T>> {
   friend class Client;
   friend class ScalarBaseBuilder<T>;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/ds/tensor.vineyard-mod
+++ b/modules/basic/ds/tensor.vineyard-mod
@@ -40,6 +40,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 template <typename T>
 class TensorBaseBuilder;
 
@@ -169,6 +174,10 @@ class GlobalTensor : public Registered<GlobalTensor> {
   friend class Client;
   friend class GlobalTensorBaseBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/ds/tuple.vineyard-mod
+++ b/modules/basic/ds/tuple.vineyard-mod
@@ -28,6 +28,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 class TupleBaseBuilder;
 
 /**
@@ -103,6 +108,10 @@ class Tuple : public Registered<Tuple> {
   friend class Client;
   friend class TupleBaseBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/stream/byte_stream.vineyard-mod
+++ b/modules/basic/stream/byte_stream.vineyard-mod
@@ -33,6 +33,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 class Client;
 
 class __attribute__((annotate("no-vineyard"))) ByteStreamWriter {
@@ -184,6 +189,10 @@ class ByteStream : public Registered<ByteStream> {
   friend class ByteStreamBaseBuilder;
   friend class ByteStreamBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 

--- a/modules/basic/stream/dataframe_stream.vineyard-mod
+++ b/modules/basic/stream/dataframe_stream.vineyard-mod
@@ -33,6 +33,11 @@ limitations under the License.
 
 namespace vineyard {
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 class Client;
 
 class __attribute__((annotate("no-vineyard"))) DataframeStreamWriter {
@@ -369,6 +374,10 @@ class DataframeStream : public Registered<DataframeStream> {
   friend class Client;
   friend class DataframeStreamBaseBuilder;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace vineyard
 


### PR DESCRIPTION

## What do these changes do?

The header files generated contains attributes defined by vineyard. When an application includes them, "unknown attribute" warnings are issued during compilation.

Here add pragma to ignore such warnings for gcc. Fix for other compiler remains to-do.

Changes to be committed:
	modified:   modules/basic/ds/array.vineyard-mod
	modified:   modules/basic/ds/arrow.vineyard-mod
	modified:   modules/basic/ds/dataframe.vineyard-mod
	modified:   modules/basic/ds/hashmap.vineyard-mod
	modified:   modules/basic/ds/pair.vineyard-mod
	modified:   modules/basic/ds/scalar.vineyard-mod
	modified:   modules/basic/ds/tensor.vineyard-mod
	modified:   modules/basic/ds/tuple.vineyard-mod
	modified:   modules/basic/stream/byte_stream.vineyard-mod
	modified:   modules/basic/stream/dataframe_stream.vineyard-mod

