### PR TITLE
Don't requires grapelite in vineyard_basic.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,3 +37,6 @@ docker/dist/
 
 # docs
 docs/_build/
+
+# go vendor
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ default.etcd/
 # setup.cfg will be generated
 /setup.cfg
 /python/vineyard/version.py
+
+# go vendor
+/**/vendor/

--- a/modules/basic/CMakeLists.txt
+++ b/modules/basic/CMakeLists.txt
@@ -2,8 +2,6 @@
 file(GLOB_RECURSE VINEYARD_MOD_SRCS "${CMAKE_CURRENT_SOURCE_DIR}"
                                     "*.vineyard-mod")
 
-find_package(libgrapelite REQUIRED)
-
 if (VINEYARD_MOD_SRCS)
     vineyard_generate(
         OUT_VAR VINEYARD_GENERATES
@@ -19,16 +17,8 @@ file(GLOB_RECURSE BASIC_SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}" "*.cc")
 add_library(vineyard_basic ${BASIC_SRC_FILES})
 target_link_libraries(vineyard_basic vineyard_client
                                      ${ARROW_SHARED_LIB}
-                                     ${MPI_CXX_LIBRARIES}
 )
 
-target_include_directories(vineyard_basic PUBLIC
-                                          ${MPI_CXX_INCLUDE_PATH}
-)
-target_include_directories(vineyard_basic PUBLIC
-    $<BUILD_INTERFACE:${LIBGRAPELITE_INCLUDE_DIRS}>
-    $<INSTALL_INTERFACE:include>
-)
 if(VINEYARD_MOD_SRCS)
     add_dependencies(vineyard_basic vineyard_basic_gen)
 endif()

--- a/modules/basic/ds/arrow_utils.h
+++ b/modules/basic/ds/arrow_utils.h
@@ -33,9 +33,6 @@ limitations under the License.
 #include "arrow/util/config.h"
 #include "glog/logging.h"
 
-#include "grape/serialization/in_archive.h"
-#include "grape/serialization/out_archive.h"
-
 #include "basic/ds/types.h"
 #include "common/util/status.h"
 
@@ -271,45 +268,5 @@ inline std::shared_ptr<arrow::DataType> type_name_to_arrow_type(
 }
 
 }  // namespace vineyard
-
-namespace grape {
-inline grape::InArchive& operator<<(grape::InArchive& in_archive,
-                                    std::shared_ptr<arrow::Schema>& schema) {
-  if (schema != nullptr) {
-    std::shared_ptr<arrow::Buffer> out;
-#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
-    CHECK_ARROW_ERROR(arrow::ipc::SerializeSchema(
-        *schema, nullptr, arrow::default_memory_pool(), &out));
-#elif defined(ARROW_VERSION) && ARROW_VERSION < 2000000
-    CHECK_ARROW_ERROR_AND_ASSIGN(
-        out, arrow::ipc::SerializeSchema(*schema, nullptr,
-                                         arrow::default_memory_pool()));
-#else
-    CHECK_ARROW_ERROR_AND_ASSIGN(
-        out,
-        arrow::ipc::SerializeSchema(*schema, arrow::default_memory_pool()));
-#endif
-    in_archive.AddBytes(out->data(), out->size());
-  }
-  return in_archive;
-}
-
-inline grape::OutArchive& operator>>(grape::OutArchive& out_archive,
-                                     std::shared_ptr<arrow::Schema>& schema) {
-  if (!out_archive.Empty()) {
-    auto buffer = std::make_shared<arrow::Buffer>(
-        reinterpret_cast<const uint8_t*>(out_archive.GetBuffer()),
-        out_archive.GetSize());
-    arrow::io::BufferReader reader(buffer);
-#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
-    CHECK_ARROW_ERROR(arrow::ipc::ReadSchema(&reader, nullptr, &schema));
-#else
-    CHECK_ARROW_ERROR_AND_ASSIGN(schema,
-                                 arrow::ipc::ReadSchema(&reader, nullptr));
-#endif
-  }
-  return out_archive;
-}
-}  // namespace grape
 
 #endif  // MODULES_BASIC_DS_ARROW_UTILS_H_

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -28,6 +28,8 @@ limitations under the License.
 #include "arrow/util/key_value_metadata.h"
 #include "boost/leaf/all.hpp"
 
+#include "grape/serialization/in_archive.h"
+#include "grape/serialization/out_archive.h"
 #include "grape/utils/vertex_array.h"
 #include "grape/worker/comm_spec.h"
 
@@ -818,5 +820,45 @@ inline boost::leaf::result<std::shared_ptr<arrow::Table>> SyncSchema(
 }
 
 }  // namespace vineyard
+
+namespace grape {
+inline InArchive& operator<<(InArchive& in_archive,
+                             std::shared_ptr<arrow::Schema>& schema) {
+  if (schema != nullptr) {
+    std::shared_ptr<arrow::Buffer> out;
+#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
+    CHECK_ARROW_ERROR(arrow::ipc::SerializeSchema(
+        *schema, nullptr, arrow::default_memory_pool(), &out));
+#elif defined(ARROW_VERSION) && ARROW_VERSION < 2000000
+    CHECK_ARROW_ERROR_AND_ASSIGN(
+        out, arrow::ipc::SerializeSchema(*schema, nullptr,
+                                         arrow::default_memory_pool()));
+#else
+    CHECK_ARROW_ERROR_AND_ASSIGN(
+        out,
+        arrow::ipc::SerializeSchema(*schema, arrow::default_memory_pool()));
+#endif
+    in_archive.AddBytes(out->data(), out->size());
+  }
+  return in_archive;
+}
+
+inline OutArchive& operator>>(OutArchive& out_archive,
+                              std::shared_ptr<arrow::Schema>& schema) {
+  if (!out_archive.Empty()) {
+    auto buffer = std::make_shared<arrow::Buffer>(
+        reinterpret_cast<const uint8_t*>(out_archive.GetBuffer()),
+        out_archive.GetSize());
+    arrow::io::BufferReader reader(buffer);
+#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
+    CHECK_ARROW_ERROR(arrow::ipc::ReadSchema(&reader, nullptr, &schema));
+#else
+    CHECK_ARROW_ERROR_AND_ASSIGN(schema,
+                                 arrow::ipc::ReadSchema(&reader, nullptr));
+#endif
+  }
+  return out_archive;
+}
+}  // namespace grape
 
 #endif  // MODULES_GRAPH_FRAGMENT_PROPERTY_GRAPH_UTILS_H_


### PR DESCRIPTION
## What do these changes do?

Move the dependency of `libgrape-lite` to `modules/graph`.

## Related issue number

Fixes #166.
