### PR TITLE
Store exception information in drivers

### DIFF
--- a/modules/io/python/drivers/io/ssh.sh
+++ b/modules/io/python/drivers/io/ssh.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -x
 HOST_NAME=$1
 shift
 

--- a/python/vineyard/io/serialization.py
+++ b/python/vineyard/io/serialization.py
@@ -32,7 +32,7 @@ def serialize(path, object_id, *args, **kwargs):
     if not parsed.scheme:
         path = 'file://' + path
     obj_type = kwargs.pop('type', 'global')
-    if serialize.__factory and serialize.__factory[obj_type]:
+    if serialize.__factory and serialize.__factory.get(obj_type):
         proc_kwargs = kwargs.copy()
         serializer = serialize.__factory[obj_type][0]
         try:
@@ -49,7 +49,7 @@ def deserialize(path, *args, **kwargs):
     if not parsed.scheme:
         path = 'file://' + path
     obj_type = kwargs.pop('type', 'global')
-    if deserialize.__factory and deserialize.__factory[obj_type]:
+    if deserialize.__factory and deserialize.__factory.get(obj_type):
         proc_kwargs = kwargs.copy()
         deserializer = deserialize.__factory[obj_type][0]
         try:

--- a/python/vineyard/io/serialization.py
+++ b/python/vineyard/io/serialization.py
@@ -35,9 +35,12 @@ def serialize(path, object_id, *args, **kwargs):
     if serialize.__factory and serialize.__factory[obj_type]:
         proc_kwargs = kwargs.copy()
         serializer = serialize.__factory[obj_type][0]
-        serializer(path, object_id, proc_kwargs.pop('vineyard_ipc_socket'), *args, **proc_kwargs)
-        return
-    raise RuntimeError('Unable to find a proper seraialization driver for %s' % path)
+        try:
+            serializer(path, object_id, proc_kwargs.pop('vineyard_ipc_socket'), *args, **proc_kwargs)
+        except Exception as e:
+            raise RuntimeError("Unable to serialize %s" % path) from e
+    else:
+        raise ValueError("No serialization driver registered for %s. type: %s" % (path, obj_type))
 
 
 @registerize
@@ -49,8 +52,12 @@ def deserialize(path, *args, **kwargs):
     if deserialize.__factory and deserialize.__factory[obj_type]:
         proc_kwargs = kwargs.copy()
         deserializer = deserialize.__factory[obj_type][0]
-        return deserializer(path, proc_kwargs.pop('vineyard_ipc_socket'), *args, **proc_kwargs)
-    raise RuntimeError('Unable to find a proper deseraialization driver for %s' % path)
+        try:
+            return deserializer(path, proc_kwargs.pop('vineyard_ipc_socket'), *args, **proc_kwargs)
+        except Exception as e:
+            raise RuntimeError("Unable to deserialize %s" % path) from e
+    else:
+        raise ValueError("No deserialization driver registered for %s. type: %s" % (path, obj_type))
 
 
 __all__ = ['serialize', 'deserialize']

--- a/python/vineyard/io/stream.py
+++ b/python/vineyard/io/stream.py
@@ -43,7 +43,7 @@ def read(path, *args, **kwargs):
             or it will tries to discovery vineyard's IPC or RPC endpoints from environment variables.
     '''
     parsed = urlparse(path)
-    if read.__factory and read.__factory[parsed.scheme]:
+    if read.__factory and read.__factory.get(parsed.scheme):
         errors = []
         for reader in read.__factory[parsed.scheme][::-1]:
             try:
@@ -78,7 +78,7 @@ def write(path, stream, *args, **kwargs):
             or it will tries to discovery vineyard's IPC or RPC endpoints from environment variables.
     '''
     parsed = urlparse(path)
-    if write.__factory and write.__factory[parsed.scheme]:
+    if write.__factory and write.__factory.get(parsed.scheme):
         errors = []
         for writer in write.__factory[parsed.scheme][::-1]:
             try:

--- a/python/vineyard/io/stream.py
+++ b/python/vineyard/io/stream.py
@@ -44,6 +44,7 @@ def read(path, *args, **kwargs):
     '''
     parsed = urlparse(path)
     if read.__factory and read.__factory[parsed.scheme]:
+        errors = []
         for reader in read.__factory[parsed.scheme][::-1]:
             try:
                 proc_kwargs = kwargs.copy()
@@ -51,9 +52,11 @@ def read(path, *args, **kwargs):
                 if r is not None:
                     return r
             except Exception as e:
-                logger.debug('failed when trying the reader: %s:\n%s', e, traceback.format_exc())
-
-    raise RuntimeError('Unable to find a proper IO driver for %s' % path)
+                errors.append('%s: %s' % (reader.__name__, traceback.format_exc()))
+        raise RuntimeError('Unable to find a proper IO driver for %s, potential causes are:\n %s' %
+                           (path, '\n'.join(errors)))
+    else:
+        raise ValueError("No IO driver registered for %s" % path)
 
 
 @registerize
@@ -76,17 +79,20 @@ def write(path, stream, *args, **kwargs):
     '''
     parsed = urlparse(path)
     if write.__factory and write.__factory[parsed.scheme]:
+        errors = []
         for writer in write.__factory[parsed.scheme][::-1]:
             try:
                 proc_kwargs = kwargs.copy()
                 writer(path, stream, proc_kwargs.pop('vineyard_ipc_socket'), *args, **proc_kwargs)
             except Exception as e:
-                logger.debug('failed when trying the writer: %s', e)
+                errors.append('%s: %s' % (writer.__name__, traceback.format_exc()))
                 continue
             else:
                 return
-
-    raise RuntimeError('Unable to find a proper IO driver for %s' % path)
+        raise RuntimeError('Unable to find a proper IO driver for %s, potential causes are:\n %s' %
+                           (path, '\n'.join(errors)))
+    else:
+        raise ValueError("No IO driver registered for %s" % path)
 
 
 def open(path, *args, mode='r', **kwargs):

--- a/python/vineyard/launcher/launcher.py
+++ b/python/vineyard/launcher/launcher.py
@@ -167,5 +167,6 @@ class Launcher(object):
     def on_exit(self, exit_content):
         ''' The on-exit handle, can be overrided to process events with type "exit".
         '''
-        print(exit_content, file=sys.stderr)
+        if exit_content and exit_content.strip():
+            print(exit_content, file=sys.stderr)
         self.dispose(True)

--- a/python/vineyard/launcher/script.py
+++ b/python/vineyard/launcher/script.py
@@ -68,7 +68,7 @@ class ScriptLauncher(Launcher):
                                       universal_newlines=True,
                                       encoding='utf-8',
                                       stdout=subprocess.PIPE,
-                                      stderr=subprocess.STDOUT)
+                                      stderr=subprocess.PIPE)
         self._status = LauncherStatus.RUNNING
 
         self._listen_thrd = threading.Thread(target=self.read_output, args=(self._proc.stdout, ))
@@ -100,7 +100,8 @@ class ScriptLauncher(Launcher):
         r = super(ScriptLauncher, self).wait(timeout=period)
         if r is not None:
             return r
-        raise RuntimeError('Failed to launch job [%s], exited with %r: %s' % (self._cmd, self._proc.poll(), remaining))
+        raise RuntimeError('Failed to launch job [%s], exited with %r: %s' %
+                           (self._cmd, self._proc.poll(), self._proc.stderr.read()))
 
     def read_output(self, stream):
         while self._proc.poll() is None:


### PR DESCRIPTION
Pass the messages in process's stderr channel to client's exception message, for easier debug.
Also remove a `-x` flag in shell cause it's doesn't bring much information and add extra noise.

Fixes #170 
