### PR TITLE
Fixes persist error when the same object is refered multiple times in different members.

### DIFF
--- a/modules/migrate/vineyard_migrate.cc
+++ b/modules/migrate/vineyard_migrate.cc
@@ -205,7 +205,7 @@ Status RunClient() {
 #endif
     if (ec) {
       LOG(ERROR) << "Failed to connect to migration peer: " << ec.message();
-      usleep(static_cast<int>(1 * 1000));
+      usleep(static_cast<int>(1 * 1000000));
       retries += 1;
     } else {
       break;

--- a/python/vineyard/.gitignore
+++ b/python/vineyard/.gitignore
@@ -1,0 +1,1 @@
+/vineyardd

--- a/python/vineyard/core/tests/__init__.py
+++ b/python/vineyard/core/tests/__init__.py
@@ -1,0 +1,17 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/vineyard/core/tests/test_client.py
+++ b/python/vineyard/core/tests/test_client.py
@@ -1,0 +1,48 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+import vineyard
+from vineyard.core import default_builder_context, default_resolver_context
+from vineyard.data import register_builtin_types
+
+register_builtin_types(default_builder_context, default_resolver_context)
+
+
+def test_persist(vineyard_client):
+    xid = vineyard_client.put(1.2345)
+    yid = vineyard_client.put(2.3456)
+    meta = vineyard.ObjectMeta()
+    meta['typename'] = 'vineyard::Pair'
+    meta.add_member('first_', xid)
+    meta.add_member('second_', yid)
+    meta.set_global(True)
+    rid = vineyard_client.create_metadata(meta)
+    vineyard_client.persist(rid)
+
+
+def test_persist_multiref(vineyard_client):
+    xid = vineyard_client.put(1.2345)
+    meta = vineyard.ObjectMeta()
+    meta['typename'] = 'vineyard::Pair'
+    meta.add_member('first_', xid)
+    meta.add_member('second_', xid)
+    meta.set_global(True)
+    rid = vineyard_client.create_metadata(meta)
+    vineyard_client.persist(rid)

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -525,7 +525,7 @@ Status VineyardServer::MigrateObject(const ObjectID object_id, const bool local,
             proc->Wait();
             if (proc->ExitCode() != 0) {
               return callback(
-                  Status::IOError("The migration server exit abnormally"),
+                  Status::IOError("The migration client exit abnormally"),
                   InvalidObjectID());
             }
 

--- a/src/server/util/meta_tree.cc
+++ b/src/server/util/meta_tree.cc
@@ -460,8 +460,13 @@ static void generate_persist_ops(json& diff, const std::string& name,
       if (global_object) {
         std::string sub_sig =
             SignatureToString(item.value()["signature"].get<Signature>());
-        ops.emplace_back(
-            IMetaService::op_t::Put("/signatures/" + sub_sig, sub_name));
+        // a global object may refer a local object multiple times using
+        // the different key.
+        if (dedup.find(sub_sig) == dedup.end()) {
+          dedup.emplace(sub_sig);
+          ops.emplace_back(
+              IMetaService::op_t::Put("/signatures/" + sub_sig, sub_name));
+        }
         sub_name = sub_sig;
       }
 


### PR DESCRIPTION
## What do these changes do?

Avoid put duplicated keys to etcd.

A test case has been added for that.

## Related issue number

N/A