### PR TITLE
Add a ObjectName type to indicate a str is a vineyard object.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ macro(find_common_libraries)
     # Don't depends on the boost::system library.
     add_compile_options(-DBOOST_ERROR_CODE_HEADER_ONLY)
     add_compile_options(-DBOOST_SYSTEM_NO_DEPRECATED)
+    # eliminate a lot of warnings for newer version of boost library.
+    add_compile_options(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
     include("cmake/FindLibUnwind.cmake")

--- a/python/client.cc
+++ b/python/client.cc
@@ -165,6 +165,13 @@ void bind_client(py::module& mod) {
           },
           "object_id"_a, "name"_a)
       .def(
+          "put_name",
+          [](ClientBase* self, const ObjectIDWrapper object_id,
+             ObjectNameWrapper const& name) {
+            throw_on_error(self->PutName(object_id, name));
+          },
+          "object_id"_a, "name"_a)
+      .def(
           "get_name",
           [](ClientBase* self, std::string const& name,
              const bool wait) -> ObjectIDWrapper {
@@ -173,8 +180,21 @@ void bind_client(py::module& mod) {
             return object_id;
           },
           "object_id"_a, py::arg("wait") = false)
+      .def(
+          "get_name",
+          [](ClientBase* self, ObjectNameWrapper const& name,
+             const bool wait) -> ObjectIDWrapper {
+            ObjectID object_id;
+            throw_on_error(self->GetName(name, object_id));
+            return object_id;
+          },
+          "object_id"_a, py::arg("wait") = false)
       .def("drop_name",
            [](ClientBase* self, std::string const& name) {
+             throw_on_error(self->DropName(name));
+           }, "name"_a)
+      .def("drop_name",
+           [](ClientBase* self, ObjectNameWrapper const& name) {
              throw_on_error(self->DropName(name));
            }, "name"_a)
       .def("migrate",

--- a/python/core.cc
+++ b/python/core.cc
@@ -203,10 +203,8 @@ void bind_core(py::module& mod) {
              return "ObjectID <\"" + VYObjectIDToString(id) + "\">";
            })
       .def("__hash__", [](const ObjectIDWrapper& id) { return ObjectID(id); })
-      .def("__eq__",
-           [](const ObjectIDWrapper& id, const ObjectIDWrapper& other) {
-             return ObjectID(id) == ObjectID(other);
-           })
+      .def("__eq__", [](const ObjectIDWrapper& id,
+                        const ObjectIDWrapper& other) { return id == other; })
       .def(py::pickle(
           [](const ObjectIDWrapper& id) {  // __getstate__
             return py::make_tuple(ObjectID(id));
@@ -217,6 +215,37 @@ void bind_core(py::module& mod) {
                   "Invalid state, cannot be pickled as ObjectID!");
             }
             return ObjectIDWrapper{tup[0].cast<ObjectID>()};
+          }));
+
+  // ObjectNameWrapper
+  py::class_<ObjectNameWrapper>(mod, "ObjectName")
+      .def(py::init<std::string const&>(), "name"_a)
+      .def("__repr__",
+           [](const ObjectNameWrapper& name) {
+             return py::repr(py::cast(std::string(name)));
+           })
+      .def("__str__",
+           [](const ObjectNameWrapper& name) {
+             return py::str(py::cast(std::string(name)));
+           })
+      .def("__hash__",
+           [](const ObjectNameWrapper& name) {
+             return py::hash(py::cast(std::string(name)));
+           })
+      .def("__eq__",
+           [](const ObjectNameWrapper& name, const ObjectNameWrapper& other) {
+             return name == other;
+           })
+      .def(py::pickle(
+          [](const ObjectNameWrapper& name) {  // __getstate__
+            return py::make_tuple(py::cast(std::string(name)));
+          },
+          [](py::tuple const& tup) {  // __setstate__
+            if (tup.size() != 1) {
+              throw std::runtime_error(
+                  "Invalid state, cannot be pickled as ObjectName!");
+            }
+            return ObjectNameWrapper{tup[0].cast<std::string>()};
           }));
 
   // Object

--- a/python/pybind11_utils.h
+++ b/python/pybind11_utils.h
@@ -21,9 +21,9 @@ limitations under the License.
 #include "pybind11/pybind11.h"
 
 #pragma GCC visibility push(default)
+#include "common/util/json.h"
 #include "common/util/status.h"
 #include "common/util/uuid.h"
-#include "common/util/json.h"
 #pragma GCC visibility pop
 
 namespace vineyard {
@@ -37,9 +37,25 @@ struct ObjectIDWrapper {
   explicit ObjectIDWrapper(const char* id)
       : internal_id(VYObjectIDFromString(id)) {}
   operator ObjectID() const { return internal_id; }
+  bool operator==(ObjectIDWrapper const& other) const {
+    return internal_id == other.internal_id;
+  }
 
  private:
   ObjectID internal_id;
+};
+
+// Wrap ObjectName to makes pybind11 work.
+struct ObjectNameWrapper {
+  explicit ObjectNameWrapper(std::string const& name) : internal_name(name) {}
+  explicit ObjectNameWrapper(const char* name) : internal_name(name) {}
+  operator std::string() const { return internal_name; }
+  bool operator==(ObjectNameWrapper const& other) const {
+    return internal_name == other.internal_name;
+  }
+
+ private:
+  const std::string internal_name;
 };
 
 }  // namespace vineyard
@@ -82,7 +98,7 @@ namespace vineyard {
 
 void throw_on_error(Status const& status);
 
-pybind11::object json_to_python(json const &value);
+pybind11::object json_to_python(json const& value);
 
 }  // namespace vineyard
 

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -55,7 +55,8 @@ if os.environ.get('VINEYARD_DEV', None) is not None:
 del _init_global_context
 
 
-from ._C import connect, IPCClient, RPCClient, Object, ObjectBuilder, ObjectID, ObjectMeta, \
+from ._C import connect, IPCClient, RPCClient, \
+    Object, ObjectBuilder, ObjectID, ObjectName, ObjectMeta, \
     InstanceStatus, Blob, BlobBuilder
 from ._C import ArrowErrorException, \
     AssertionFailedException, \

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -4,7 +4,7 @@
 import logging
 
 from ._C import _add_doc, connect, ClientBase, IPCClient, RPCClient, \
-    Object, ObjectBuilder, ObjectID, ObjectMeta, InstanceStatus, \
+    Object, ObjectBuilder, ObjectID, ObjectName, ObjectMeta, InstanceStatus, \
     Blob, BlobBuilder
 
 
@@ -284,6 +284,23 @@ are provided to interact with the external python world.
     74516723525190
 ''')
 
+add_doc(
+    ObjectName, r'''
+Opaque type for vineyard's object name. ObjectName wraps a string, but it let users know
+whether the variable represents a vineyard object, and do some smart dispatch based on that.
+Wrapper utilities are provided to interact with the external python world.
+
+.. code:: python
+
+    >>> name = ObjectName("a_tensor")
+    >>> name
+    'a_tensor'
+    >>> repr(name)
+    "'a_tensor'"
+    >>> print(name)
+    a_tensor
+''')
+
 add_doc(Object, r'''
 Base class for vineyard objects.
 ''')
@@ -434,7 +451,7 @@ Returns:
 
 add_doc(
     ClientBase.put_name, r'''
-.. method:: put_name(object_id: ObjectID, name: str) -> None
+.. method:: put_name(object_id: ObjectID, name: str or ObjectName) -> None
     :noindex:
 
 Associate the given object id with a name. An :class:`ObjectID` can be assoicated with more
@@ -447,7 +464,7 @@ Parameters:
 
 add_doc(
     ClientBase.get_name, r'''
-.. method:: get_name(name: str, wait: bool = False) -> ObjectID
+.. method:: get_name(name: str or ObjectName, wait: bool = False) -> ObjectID
     :noindex:
 
 Get the associated object id of the given name.
@@ -465,7 +482,7 @@ Return:
 
 add_doc(
     ClientBase.drop_name, r'''
-.. method:: drop_name(name: str) -> None
+.. method:: drop_name(name: str or ObjectName) -> None
     :noindex:
 
 Remove the assoication of the given name.


### PR DESCRIPTION
## What do these changes do?

That is useful, when we use a variable to represent a vineyard object. We don't have the object ID and just have a name, and the `get_name` transformation is not available currently.

We need such a wrapper to differ a ordinary string with a string that is actually a name for vineyard object.

## Related issue number

N/A