### PR TITLE
Force vineyard-io as a platlib, but with a universal tag.

### DIFF
--- a/modules/io/setup.py
+++ b/modules/io/setup.py
@@ -19,6 +19,27 @@
 import os
 
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+from wheel.bdist_wheel import bdist_wheel
+
+
+class bdist_wheel_plat(bdist_wheel):
+    def finalize_options(self):
+        bdist_wheel.finalize_options(self)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        self.root_is_pure = True
+        tag = bdist_wheel.get_tag(self)
+        self.root_is_pure = False
+        return tag
+
+
+class install_plat(install):
+    def finalize_options(self):
+        self.install_lib = self.install_platlib
+        install.finalize_options(self)
+
 
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
@@ -57,12 +78,21 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
+    cmdclass={
+        'bdist_wheel': bdist_wheel_plat,
+        "install": install_plat
+    },
     entry_points={},
+    setup_requires=[
+        'setuptools',
+        'wheel',
+    ],
     extras_require={
         'dev': [
             'pytest',
         ],
     },
+    platform=['POSIX', 'MacOS'],
     license="Apache License 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/modules/migrate/vineyard_migrate_stream.cc
+++ b/modules/migrate/vineyard_migrate_stream.cc
@@ -88,11 +88,11 @@ Status Serve(Client& client, RPCClient& rpc_client,
     asio::read(socket, asio::buffer(&buffer_size, sizeof(size_t)));
     VLOG(10) << "Recieve buffer size " << buffer_size;
     if (buffer_size == std::numeric_limits<size_t>::max()) {
-      client.StopStream(target_id, false);
+      RETURN_ON_ERROR(client.StopStream(target_id, false));
       LOG(INFO) << "The server finishes its job, exit normally";
       return Status::OK();
     } else if (buffer_size == std::numeric_limits<size_t>::max() - 1) {
-      client.StopStream(target_id, true);
+      RETURN_ON_ERROR(client.StopStream(target_id, true));
       LOG(ERROR) << "The server exit unnormally as the source stream corrupted";
       return Status::StreamFailed();
     } else {

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         'libclang',
         'parsec',
         'setuptools',
+        'wheel',
     ],
     install_requires=[
         'numpy',
@@ -132,6 +133,7 @@ setup(
             "kubernetes",
         ],
     },
+    platform=['POSIX', 'MacOS'],
     license="Apache License 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## What do these changes do?

To make sure package `vineyard` and `vineyard-io` are installed to the same directory.

## Related issue number

Fixes #111.
