### PR TITLE
Implements a shared_memory.{SharedMemory, ShareableList} interface on vineyard

### DIFF
--- a/docs/notes/python_api.rst
+++ b/docs/notes/python_api.rst
@@ -59,6 +59,15 @@ Primitives
 .. autoclass:: BlobBuilder
     :members:
 
+Shared Memory
+-------------
+
+.. autoclass:: vineyard.shared_memory.SharedMemory
+    :members:
+
+.. autoclass:: vineyard.shared_memory.ShareableList
+    :members:
+
 Deployment
 ----------
 

--- a/python/client.cc
+++ b/python/client.cc
@@ -296,7 +296,10 @@ void bind_client(py::module& mod) {
       .def(
           "get_object",
           [](Client* self, const ObjectIDWrapper object_id) {
-            return self->GetObject(object_id);
+            // receive the status to throw a more precise exception when failed.
+            std::shared_ptr<Object> object;
+            throw_on_error(self->GetObject(object_id, object));
+            return object;
           },
           "object_id"_a)
       .def(
@@ -353,7 +356,10 @@ void bind_client(py::module& mod) {
       .def(
           "get_object",
           [](RPCClient* self, const ObjectIDWrapper object_id) {
-            return self->GetObject(object_id);
+            // receive the status to throw a more precise exception when failed.
+            std::shared_ptr<Object> object;
+            throw_on_error(self->GetObject(object_id, object));
+            return object;
           },
           "object_id"_a)
       .def(

--- a/python/client.cc
+++ b/python/client.cc
@@ -151,7 +151,8 @@ void bind_client(py::module& mod) {
           "object_id"_a)
       .def(
           "shallow_copy",
-          [](ClientBase* self, const ObjectIDWrapper object_id) -> ObjectIDWrapper {
+          [](ClientBase* self,
+             const ObjectIDWrapper object_id) -> ObjectIDWrapper {
             ObjectID target_id;
             throw_on_error(self->ShallowCopy(object_id, target_id));
             return target_id;
@@ -189,35 +190,45 @@ void bind_client(py::module& mod) {
             return object_id;
           },
           "object_id"_a, py::arg("wait") = false)
-      .def("drop_name",
-           [](ClientBase* self, std::string const& name) {
-             throw_on_error(self->DropName(name));
-           }, "name"_a)
-      .def("drop_name",
-           [](ClientBase* self, ObjectNameWrapper const& name) {
-             throw_on_error(self->DropName(name));
-           }, "name"_a)
-      .def("migrate",
-          [](ClientBase *self, const ObjectID object_id) -> ObjectIDWrapper {
+      .def(
+          "drop_name",
+          [](ClientBase* self, std::string const& name) {
+            throw_on_error(self->DropName(name));
+          },
+          "name"_a)
+      .def(
+          "drop_name",
+          [](ClientBase* self, ObjectNameWrapper const& name) {
+            throw_on_error(self->DropName(name));
+          },
+          "name"_a)
+      .def(
+          "migrate",
+          [](ClientBase* self, const ObjectID object_id) -> ObjectIDWrapper {
             ObjectID target_id = InvalidObjectID();
             throw_on_error(self->MigrateObject(object_id, target_id));
             return target_id;
-          }, "object_id"_a)
-      .def("migrate_stream",
-          [](ClientBase *self, const ObjectID object_id) -> ObjectIDWrapper {
+          },
+          "object_id"_a)
+      .def(
+          "migrate_stream",
+          [](ClientBase* self, const ObjectID object_id) -> ObjectIDWrapper {
             ObjectID target_id = InvalidObjectID();
             throw_on_error(self->MigrateStream(object_id, target_id));
             return target_id;
-          }, "object_id"_a)
+          },
+          "object_id"_a)
       .def_property_readonly("connected", &Client::Connected)
       .def_property_readonly("instance_id", &Client::instance_id)
       .def_property_readonly(
           "meta",
           [](ClientBase* self)
-              -> std::map<uint64_t, std::unordered_map<std::string, py::object>> {
+              -> std::map<uint64_t,
+                          std::unordered_map<std::string, py::object>> {
             std::map<uint64_t, json> meta;
             throw_on_error(self->ClusterInfo(meta));
-            std::map<uint64_t, std::unordered_map<std::string, py::object>> meta_to_return;
+            std::map<uint64_t, std::unordered_map<std::string, py::object>>
+                meta_to_return;
             for (auto const& kv : meta) {
               std::unordered_map<std::string, py::object> element;
               if (!kv.second.empty()) {
@@ -314,7 +325,8 @@ void bind_client(py::module& mod) {
           "object_ids"_a)
       .def(
           "get_meta",
-          [](Client* self, ObjectIDWrapper const& object_id, bool const sync_remote) -> ObjectMeta {
+          [](Client* self, ObjectIDWrapper const& object_id,
+             bool const sync_remote) -> ObjectMeta {
             ObjectMeta meta;
             // FIXME: do we really not need to sync from etcd? We assume the
             // object is a local object
@@ -324,8 +336,8 @@ void bind_client(py::module& mod) {
           "object_id"_a, py::arg("sync_remote") = false)
       .def(
           "get_metas",
-          [](Client* self, std::vector<ObjectIDWrapper> const& object_ids, bool const sync_remote)
-              -> std::vector<ObjectMeta> {
+          [](Client* self, std::vector<ObjectIDWrapper> const& object_ids,
+             bool const sync_remote) -> std::vector<ObjectMeta> {
             std::vector<ObjectMeta> metas;
             // FIXME: do we really not need to sync from etcd? We assume the
             // object is a local object
@@ -417,22 +429,24 @@ void bind_client(py::module& mod) {
            }
            throw_on_error(Status::ConnectionFailed(
                "Failed to resolve IPC socket or RPC endpoint of vineyard "
-               "server from environment variables VINEYARD_IPC_SOCKET or VINEYARD_RPC_ENDPOINT."));
+               "server from environment variables VINEYARD_IPC_SOCKET or "
+               "VINEYARD_RPC_ENDPOINT."));
            return py::none();
          },
          py::arg("target") = py::none())
       .def(
           "connect",
           [](std::string const& endpoint) -> py::object {
-            return py::cast(ClientManager<Client>::GetManager()->Connect(endpoint));
+            return py::cast(
+                ClientManager<Client>::GetManager()->Connect(endpoint));
           },
           "endpoint"_a)
       .def(
           "connect",
           [](std::string const& host, const uint32_t port) {
             std::string rpc_endpoint = host + ":" + std::to_string(port);
-            return py::cast(ClientManager<RPCClient>::GetManager()->Connect(
-                rpc_endpoint));
+            return py::cast(
+                ClientManager<RPCClient>::GetManager()->Connect(rpc_endpoint));
           },
           "host"_a, "port"_a)
       .def(

--- a/python/core.cc
+++ b/python/core.cc
@@ -309,17 +309,17 @@ void bind_core(py::module& mod) {
       .def_property_readonly(
           "address",
           [](Blob* self) { return reinterpret_cast<uintptr_t>(self->data()); })
-      .def_property_readonly(
-          "buffer",
-          [](Blob& blob) -> py::object {
-            auto buffer = blob.Buffer();
-            if (buffer == nullptr) {
-              return py::none();
-            } else {
-              return py::memoryview::from_memory(
-                  const_cast<uint8_t*>(buffer->data()), buffer->size(), true);
-            }
-          })
+      .def_property_readonly("buffer",
+                             [](Blob& blob) -> py::object {
+                               auto buffer = blob.Buffer();
+                               if (buffer == nullptr) {
+                                 return py::none();
+                               } else {
+                                 return py::memoryview::from_memory(
+                                     const_cast<uint8_t*>(buffer->data()),
+                                     buffer->size(), true);
+                               }
+                             })
       .def_buffer([](Blob& blob) -> py::buffer_info {
         return py::buffer_info(const_cast<char*>(blob.data()), sizeof(int8_t),
                                py::format_descriptor<int8_t>::format(), 1,
@@ -361,7 +361,9 @@ void bind_core(py::module& mod) {
             self->AddKeyValue(key, value);
           },
           "key"_a, "value"_a)
-      .def("abort", [](BlobWriter *self, Client &client) {
+      .def(
+          "abort",
+          [](BlobWriter* self, Client& client) {
             throw_on_error(self->Abort(client));
           },
           "client"_a)
@@ -386,17 +388,17 @@ void bind_core(py::module& mod) {
                              [](BlobWriter* self) {
                                return reinterpret_cast<uintptr_t>(self->data());
                              })
-      .def_property_readonly(
-          "buffer",
-          [](BlobWriter& blob) -> py::object {
-            auto buffer = blob.Buffer();
-            if (buffer == nullptr) {
-              return py::none();
-            } else {
-              return py::memoryview::from_memory(
-                  buffer->mutable_data(), buffer->size(), false);
-            }
-          })
+      .def_property_readonly("buffer",
+                             [](BlobWriter& blob) -> py::object {
+                               auto buffer = blob.Buffer();
+                               if (buffer == nullptr) {
+                                 return py::none();
+                               } else {
+                                 return py::memoryview::from_memory(
+                                     buffer->mutable_data(), buffer->size(),
+                                     false);
+                               }
+                             })
       .def_buffer([](BlobWriter& blob) -> py::buffer_info {
         return py::buffer_info(blob.data(), sizeof(int8_t),
                                py::format_descriptor<int8_t>::format(), 1,

--- a/python/core.cc
+++ b/python/core.cc
@@ -361,6 +361,10 @@ void bind_core(py::module& mod) {
             self->AddKeyValue(key, value);
           },
           "key"_a, "value"_a)
+      .def("abort", [](BlobWriter *self, Client &client) {
+            throw_on_error(self->Abort(client));
+          },
+          "client"_a)
       .def(
           "copy",
           [](BlobWriter* self, size_t const offset, uintptr_t ptr,

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -850,6 +850,10 @@ add_doc(BlobBuilder.size, r'''
 Size of this blob builder.
 ''')
 
+add_doc(BlobBuilder.abort, r'''
+Abort the blob builder if it is not sealed yet.
+''')
+
 add_doc(
     BlobBuilder.copy, r'''
 .. method:: copy(self, offset: int, ptr: int, size: int)

--- a/python/vineyard/shared_memory/__init__.py
+++ b/python/vineyard/shared_memory/__init__.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .shared_memory import SharedMemory, ShareableList

--- a/python/vineyard/shared_memory/shared_memory.py
+++ b/python/vineyard/shared_memory/shared_memory.py
@@ -63,12 +63,9 @@ class SharedMemory:
                 raise ValueError("'name' can only be None if create=True")
         else:
             if size != 0:
-                warnings.warn(
-                    "'size' will take no effect if create=False",
-                )
+                warnings.warn("'size' will take no effect if create=False", )
             if name is None:
                 raise ValueError("'name' cannot be None if create=False")
-
 
         self._name = None
         self._size = None
@@ -165,6 +162,10 @@ class ShareableList(multiprocessing.shared_memory.ShareableList):
     multiprocessing.shared_memory.ShareableList
     '''
 
+    # yapf: disable
+
+    # note that the implementation of ``__init__`` entirely comes from multiprocessing.shared_memory.
+
     def __init__(self, vineyard_client, sequence=None, *, name=None):
         if name is None or sequence is not None:
             if name is not None:
@@ -243,6 +244,8 @@ class ShareableList(multiprocessing.shared_memory.ShareableList):
                 )
             )
 
+    # yapf: enable
+
     def freeze(self):
         ''' Make the shareable list immutable and visible for other vineyard clients.
         '''
@@ -251,4 +254,4 @@ class ShareableList(multiprocessing.shared_memory.ShareableList):
     __class_getitem__ = classmethod(types.GenericAlias)
 
 
-__all__ = [ 'SharedMemory', 'ShareableList' ]
+__all__ = ['SharedMemory', 'ShareableList']

--- a/python/vineyard/shared_memory/shared_memory.py
+++ b/python/vineyard/shared_memory/shared_memory.py
@@ -1,0 +1,254 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+'''
+The shared_memory module provides similar interface like multiprocessing.shared_memory
+for direct access shared memory backed by vineyard across processes.
+
+The API is kept consistent with multiprocessing.shared_memory but the semantics is slightly
+different. For vineyard, to make the shared memory visible for other process, a explictly
+``seal`` or ``close`` operation is needed.
+
+Refer to the documentation of multiprocessing.shared_memory for details.
+'''
+
+import multiprocessing.shared_memory
+import struct
+import types
+import warnings
+
+from vineyard._C import ObjectID
+
+
+class SharedMemory:
+    def __init__(self, vineyard_client, name=None, create=False, size=0):
+        ''' Create or obtain a shared memory block that backed by vineyard.
+
+            Parameters
+            ----------
+            vineyard_client:
+                The vineyard IPC or RPC client.
+            name:
+                The vineyard ObjectID, could be vineyard.ObjectID, int or stringified ObjectID.
+            create:
+                Whether to create a new shared memory block or just obtain existing one.
+            size:
+                Size of the shared memory block.
+
+            See Also
+            --------
+            multiprocessing.shared_memory.SharedMemory
+        '''
+        if not size >= 0:
+            raise ValueError("'size' must be a positive integer")
+        if create:
+            if size == 0:
+                raise ValueError("'size' must be a positive number different from zero")
+            if name is not None:
+                raise ValueError("'name' can only be None if create=True")
+        else:
+            if size != 0:
+                warnings.warn(
+                    "'size' will take no effect if create=False",
+                )
+            if name is None:
+                raise ValueError("'name' cannot be None if create=False")
+
+
+        self._name = None
+        self._size = None
+        self._buf = None
+        self._blob, self._blob_builder = None, None
+        self._vineyard_client = vineyard_client
+
+        if create:
+            self._blob_builder = vineyard_client.create_blob(size)
+            self._name = self._blob_builder.id
+            self._size = size
+            self._buf = memoryview(self._blob_builder)
+        else:
+            self._blob = vineyard_client.get_object(ObjectID(name))
+            self._name = self._blob.id
+            self._size = self._blob.size
+            self._buf = memoryview(self._blob)
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (
+                self.name,
+                False,
+                self.size,
+            ),
+        )
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.name!r}, size={self.size})'
+
+    @property
+    def buf(self):
+        "A memoryview of contents of the shared memory block."
+        return self._buf
+
+    @property
+    def name(self):
+        "Unique name that identifies the shared memory block."
+        return repr(self._name)
+
+    @property
+    def size(self):
+        "Size in bytes."
+        return self._size
+
+    def seal(self):
+        "Seal the shared memory to make it visible for other processes."
+        if self._blob_builder:
+            self._blob = self._blob_builder.seal(self._vineyard_client)
+            self._blob_builder = None
+        return self
+
+    def close(self):
+        self.seal()
+
+    def unlink(self):
+        """Requests that the underlying shared memory block be destroyed."""
+        if self._blob:
+            self._vineyard_client.delete(self._blob.id)
+            self._blob = None
+        else:
+            self._blob_builder.abort(self._vineyard_client)
+            self._blob_builder = None
+        self._buf = None
+
+
+_encoding = "utf8"
+
+
+class ShareableList(multiprocessing.shared_memory.ShareableList):
+    '''
+    Pattern for a mutable list-like object shareable via a shared
+    memory block.  It differs from the built-in list type in that these
+    lists can not change their overall length (i.e. no append, insert,
+    etc.)
+
+    Because values are packed into a memoryview as bytes, the struct
+    packing format for any storable value must require no more than 8
+    characters to describe its format.
+
+    The ShareableList in vineyard differs slightly with its equivalent
+    in the multiprocessing.shared_memory.ShareableList, as it becomes
+    immutable after obtaining from the vineyard backend.
+
+    See Also
+    --------
+    multiprocessing.shared_memory.ShareableList
+    '''
+
+    def __init__(self, vineyard_client, sequence=None, *, name=None):
+        if name is None or sequence is not None:
+            if name is not None:
+                warnings.warn(
+                    "'name' will take no effect as we are going to create a ShareableList",
+                )
+
+            sequence = sequence or ()
+            _formats = [
+                self._types_mapping[type(item)]
+                    if not isinstance(item, (str, bytes))
+                    else self._types_mapping[type(item)] % (
+                        self._alignment * (len(item) // self._alignment + 1),
+                    )
+                for item in sequence
+            ]
+            self._list_len = len(_formats)
+            assert sum(len(fmt) <= 8 for fmt in _formats) == self._list_len
+            offset = 0
+            # The offsets of each list element into the shared memory's
+            # data area (0 meaning the start of the data area, not the start
+            # of the shared memory area).
+            self._allocated_offsets = [0]
+            for fmt in _formats:
+                offset += self._alignment if fmt[-1] != "s" else int(fmt[:-1])
+                self._allocated_offsets.append(offset)
+            _recreation_codes = [
+                self._extract_recreation_code(item) for item in sequence
+            ]
+            requested_size = struct.calcsize(
+                "q" + self._format_size_metainfo +
+                "".join(_formats) +
+                self._format_packing_metainfo +
+                self._format_back_transform_codes
+            )
+
+            self.shm = SharedMemory(vineyard_client, create=True, size=requested_size)
+        else:
+            self.shm = SharedMemory(vineyard_client, name)
+
+        if sequence is not None:
+            _enc = _encoding
+            struct.pack_into(
+                "q" + self._format_size_metainfo,
+                self.shm.buf,
+                0,
+                self._list_len,
+                *(self._allocated_offsets)
+            )
+            struct.pack_into(
+                "".join(_formats),
+                self.shm.buf,
+                self._offset_data_start,
+                *(v.encode(_enc) if isinstance(v, str) else v for v in sequence)
+            )
+            struct.pack_into(
+                self._format_packing_metainfo,
+                self.shm.buf,
+                self._offset_packing_formats,
+                *(v.encode(_enc) for v in _formats)
+            )
+            struct.pack_into(
+                self._format_back_transform_codes,
+                self.shm.buf,
+                self._offset_back_transform_codes,
+                *(_recreation_codes)
+            )
+
+        else:
+            self._list_len = len(self)  # Obtains size from offset 0 in buffer.
+            self._allocated_offsets = list(
+                struct.unpack_from(
+                    self._format_size_metainfo,
+                    self.shm.buf,
+                    1 * 8
+                )
+            )
+
+    def freeze(self):
+        ''' Make the shareable list immutable and visible for other vineyard clients.
+        '''
+        self.shm.seal()
+
+    __class_getitem__ = classmethod(types.GenericAlias)
+
+
+__all__ = [ 'SharedMemory', 'ShareableList' ]

--- a/python/vineyard/shared_memory/shared_memory.py
+++ b/python/vineyard/shared_memory/shared_memory.py
@@ -29,7 +29,6 @@ Refer to the documentation of multiprocessing.shared_memory for details.
 
 import multiprocessing.shared_memory
 import struct
-import types
 import warnings
 
 from vineyard._C import ObjectID
@@ -250,8 +249,6 @@ class ShareableList(multiprocessing.shared_memory.ShareableList):
         ''' Make the shareable list immutable and visible for other vineyard clients.
         '''
         self.shm.seal()
-
-    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 __all__ = ['SharedMemory', 'ShareableList']

--- a/python/vineyard/shared_memory/tests/__init__.py
+++ b/python/vineyard/shared_memory/tests/__init__.py
@@ -1,0 +1,17 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/vineyard/shared_memory/tests/test_shared_memory.py
+++ b/python/vineyard/shared_memory/tests/test_shared_memory.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+import vineyard
+import vineyard.shared_memory as shared_memory
+
+
+def test_shareable_list(vineyard_client):
+    a = shared_memory.ShareableList(vineyard_client, ("a", b"bb", 1234, 56789.01234))
+    a[0] = "bbbbbb"
+    a.freeze()
+
+    b = shared_memory.ShareableList(vineyard_client, name=a.shm.name)
+    assert len(a) == len(b)
+    for x, y in zip(a, b):
+        assert x == y
+
+    b.unlink()

--- a/python/vineyard/shared_memory/tests/test_shared_memory.py
+++ b/python/vineyard/shared_memory/tests/test_shared_memory.py
@@ -32,4 +32,4 @@ def test_shareable_list(vineyard_client):
     for x, y in zip(a, b):
         assert x == y
 
-    b.unlink()
+    b.shm.unlink()

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -361,6 +361,11 @@ class Client : public ClientBase {
   Status GetBuffers(const std::unordered_set<ObjectID>& ids,
                     std::unordered_map<ObjectID, Payload>& objects);
 
+  /**
+   * N.B.: can only be used for **UN-SEALED** blob writers.
+   */
+  Status DropBuffer(const ObjectID id, const int fd);
+
   Status mmapToClient(int fd, int64_t map_size, bool readonly, uint8_t** ptr);
 
   std::unordered_map<int, std::unique_ptr<MmapEntry>> mmap_table_;

--- a/src/client/ds/blob.h
+++ b/src/client/ds/blob.h
@@ -161,6 +161,13 @@ class BlobWriter : public ObjectBuilder {
   Status Build(Client& client) override;
 
   /**
+   * @brief Abort the blob builder.
+   *
+   * @param client Release the blob builder object if it is not sealed.
+   */
+  Status Abort(Client& client);
+
+  /**
    * @brief Add key-value metadata for the blob.
    *
    * @param key The key of the metadata.
@@ -185,11 +192,12 @@ class BlobWriter : public ObjectBuilder {
   std::shared_ptr<Object> _Seal(Client& client) override;
 
  private:
-  BlobWriter(ObjectID const object_id,
+  BlobWriter(ObjectID const object_id, int const fd,
              std::shared_ptr<arrow::MutableBuffer> const& buffer)
-      : object_id_(object_id), buffer_(buffer) {}
+      : object_id_(object_id), fd_(fd), buffer_(buffer) {}
 
   ObjectID object_id_;
+  int fd_;
   std::shared_ptr<arrow::MutableBuffer> buffer_;
   // Allowing blobs have extra key-value metadata
   std::unordered_map<std::string, std::string> metadata_;

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -90,10 +90,12 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::OpenStreamRequest;
   } else if (str_type == "migrate_object_request") {
     return CommandType::MigrateObjectRequest;
-  } else if (str_type == "create_remote_buffer") {
+  } else if (str_type == "create_remote_buffer_request") {
     return CommandType::CreateRemoteBufferRequest;
-  } else if (str_type == "get_remote_buffers") {
+  } else if (str_type == "get_remote_buffers_request") {
     return CommandType::GetRemoteBuffersRequest;
+  } else if (str_type == "drop_buffer_request") {
+    return CommandType::DropBufferRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -354,6 +356,32 @@ Status ReadGetRemoteBuffersRequest(const json& root,
   for (size_t i = 0; i < num; ++i) {
     ids.push_back(root[std::to_string(i)].get<ObjectID>());
   }
+  return Status::OK();
+}
+
+void WriteDropBufferRequest(const ObjectID id, std::string& msg) {
+  json root;
+  root["type"] = "drop_buffer_request";
+  root["id"] = id;
+
+  encode_msg(root, msg);
+}
+
+Status ReadDropBufferRequest(const json& root, ObjectID& id) {
+  RETURN_ON_ASSERT(root["type"] == "drop_buffer_request");
+  id = root["id"].get<ObjectID>();
+  return Status::OK();
+}
+
+void WriteDropBufferReply(std::string& msg) {
+  json root;
+  root["type"] = "drop_buffer_reply";
+
+  encode_msg(root, msg);
+}
+
+Status ReadDropBufferReply(const json& root) {
+  CHECK_IPC_ERROR(root, "drop_buffer_reply");
   return Status::OK();
 }
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -60,6 +60,7 @@ enum class CommandType {
   MigrateObjectRequest = 29,
   CreateRemoteBufferRequest = 30,
   GetRemoteBuffersRequest = 31,
+  DropBufferRequest = 32,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -196,6 +197,14 @@ void WriteGetRemoteBuffersRequest(const std::unordered_set<ObjectID>& ids,
 
 Status ReadGetRemoteBuffersRequest(const json& root,
                                    std::vector<ObjectID>& ids);
+
+void WriteDropBufferRequest(const ObjectID id, std::string& msg);
+
+Status ReadDropBufferRequest(const json& root, ObjectID& id);
+
+void WriteDropBufferReply(std::string& msg);
+
+Status ReadDropBufferReply(const json& root);
 
 void WritePutNameRequest(const ObjectID object_id, const std::string& name,
                          std::string& msg);

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -74,6 +74,8 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
    */
   bool doCreateRemoteBuffer(const json& root);
 
+  bool doDropBuffer(const json& root);
+
   bool doGetData(const json& root);
 
   bool doListData(const json& root);

--- a/test/runner.py
+++ b/test/runner.py
@@ -291,6 +291,7 @@ def run_python_tests(etcd_endpoints, with_migration):
         subprocess.check_call(['pytest', '-s', '-vvv',
                                'python/vineyard/core',
                                'python/vineyard/data',
+                               'python/vineyard/shared_memory',
                                '--vineyard-ipc-socket=%s' % VINEYARD_CI_IPC_SOCKET,
                                '--vineyard-endpoint=localhost:%s' % rpc_socket_port],
                                cwd=os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))


### PR DESCRIPTION
## What do these changes do?

Implemements `shared_memory.{SharedMemory, ShareableList}` interface using the same interface design of `multiprocessing.shared_memory`.

That would bring benefits to python users.

## Related issue number

Fixes #195.

This pull request also implements "Abort" semantic for `BlobWriter`, for #100.