### PR TITLE
Makes the implementation of GetMallocMapinfo behaves in logarithmic time.

### DIFF
--- a/src/server/memory/malloc.cc
+++ b/src/server/memory/malloc.cc
@@ -47,7 +47,13 @@ static ptrdiff_t pointer_distance(void const* pfrom, void const* pto) {
 void GetMallocMapinfo(void* addr, int* fd, int64_t* map_size,
                       ptrdiff_t* offset) {
   auto entry = mmap_records.lower_bound(addr);
+  if (!mmap_records.empty()) {
+    std::advance(entry, -1);
+  }
   auto upper = mmap_records.upper_bound(addr);
+  if (upper != mmap_records.end()) {
+    std::advance(upper, 1);
+  }
   while (entry != upper) {
     if (entry->first <= addr &&
         addr < pointer_advance(entry->first, entry->second.size)) {

--- a/src/server/memory/malloc.h
+++ b/src/server/memory/malloc.h
@@ -32,6 +32,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 
+#include <map>
 #include <unordered_map>
 
 namespace plasma {
@@ -44,10 +45,10 @@ struct MmapRecord {
   int64_t size;
 };
 
-/// Hashtable that contains one entry per segment that we got from the OS
+/// Table that contains one entry per segment that we got from the OS
 /// via mmap. Associates the address of that segment with its file descriptor
 /// and size.
-extern std::unordered_map<void*, MmapRecord> mmap_records;
+extern std::map<void*, MmapRecord> mmap_records;
 
 }  // namespace plasma
 


### PR DESCRIPTION
## What do these changes do?

There's a TODO in the original code referred from plasma.

The patch could be backported to upstream as well.