### PR TITLE
allowing folly::dynamic oid of object/array/double/bool type to be hashed

### DIFF
--- a/modules/graph/utils/partitioner.h
+++ b/modules/graph/utils/partitioner.h
@@ -114,12 +114,10 @@ class HashPartitioner<folly::dynamic> {
 
   inline fid_t GetPartitionId(const oid_t& oid) const {
     size_t hash_value;
-    if (oid.isInt()) {
-      hash_value = std::hash<folly::dynamic>()(oid);
-    } else if (oid.isString()) {
+    if (oid.isString()) {
       hash_value = std::hash<std::string>()(oid.getString());
     } else {
-      LOG(FATAL) << "Not dynamic type: null/object/array/bool/double";
+      hash_value = std::hash<folly::dynamic>()(oid);
     }
     return static_cast<fid_t>(static_cast<uint64_t>(hash_value) % fnum_);
   }


### PR DESCRIPTION
## What do these changes do?
since [this commit](https://github.com/facebook/folly/commit/c391dc14a668aa87df295e1546279f7bca85f0ce#diff-735b6af000822abdde29d4ac622393f651f4c73e6025e48e2c6c1c126da2fde6)  folly support hash of  object/array type folly::dynamic, we should allowing folly::dynamic oid of object/array/double/bool type to be hashed

